### PR TITLE
Add ai-tools-gateway module: initial MCP server skeleton

### DIFF
--- a/ticket-manager/ai-tools-gateway/README.md
+++ b/ticket-manager/ai-tools-gateway/README.md
@@ -1,0 +1,57 @@
+# ai-tools-gateway
+
+`ai-tools-gateway` jest **MCP Serverem** dla `ai-agent`.
+
+## Kanały komunikacji
+
+### A) `ai-agent` ⇄ `ai-tools-gateway` (MCP)
+
+```text
+[ai-agent]
+  Spring AI MCP Client
+        |
+        | tools/list, tools/call (MCP)
+        v
+[ai-tools-gateway]
+  Spring AI MCP Server (@Tool)
+```
+
+W tej warstwie agent nie wywołuje klasycznych endpointów REST typu `/api/v1/tools/...`.
+
+### B) `ai-tools-gateway` ⇄ domenowe mikroserwisy (REST/Feign/gRPC)
+
+```text
+[ai-tools-gateway @Tool]
+        |
+        | Feign / REST / gRPC
+        v
+[order-service] [crm-service] [billing-service]
+```
+
+MCP służy do komunikacji agentowej, a nie do zastąpienia całej komunikacji między mikroserwisami domenowymi.
+
+## Konfiguracja MCP server (gateway)
+
+W `src/main/resources/application.yml`:
+
+```yaml
+spring:
+  ai:
+    mcp:
+      server:
+        enabled: true
+        protocol: STREAMABLE
+        endpoint: /mcp
+        annotation-scanner:
+          enabled: true
+```
+
+## Przykładowa konfiguracja MCP client (`ai-agent`)
+
+Przykład znajduje się w pliku:
+
+- `src/main/resources/application-mcp-client-example.yml`
+
+## Dostępne narzędzie
+
+- `order-service.searchOrders` — deleguje do `order-service` przez `OrderClient`.

--- a/ticket-manager/ai-tools-gateway/pom.xml
+++ b/ticket-manager/ai-tools-gateway/pom.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>pl.ticket</groupId>
+        <artifactId>ticket</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>ai-tools-gateway</artifactId>
+
+    <properties>
+        <maven.compiler.source>19</maven.compiler.source>
+        <maven.compiler.target>19</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <spring-ai.version>1.0.0-M6</spring-ai.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.ai</groupId>
+                <artifactId>spring-ai-bom</artifactId>
+                <version>${spring-ai.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-starter-mcp-server-webmvc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-openfeign</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.0.3</version>
+        </dependency>
+        <dependency>
+            <groupId>pl.ticket</groupId>
+            <artifactId>feign</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>pl.ticket</groupId>
+            <artifactId>common</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/ticket-manager/ai-tools-gateway/src/main/java/pl/ticket/aitoolsgateway/AiToolsGatewayApplication.java
+++ b/ticket-manager/ai-tools-gateway/src/main/java/pl/ticket/aitoolsgateway/AiToolsGatewayApplication.java
@@ -1,0 +1,14 @@
+package pl.ticket.aitoolsgateway;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+
+@SpringBootApplication
+@EnableFeignClients(basePackages = "pl.ticket.feign")
+public class AiToolsGatewayApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(AiToolsGatewayApplication.class, args);
+    }
+}

--- a/ticket-manager/ai-tools-gateway/src/main/java/pl/ticket/aitoolsgateway/config/AuthFeignInterceptor.java
+++ b/ticket-manager/ai-tools-gateway/src/main/java/pl/ticket/aitoolsgateway/config/AuthFeignInterceptor.java
@@ -1,0 +1,26 @@
+package pl.ticket.aitoolsgateway.config;
+
+import feign.RequestInterceptor;
+import feign.RequestTemplate;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Configuration
+public class AuthFeignInterceptor implements RequestInterceptor {
+
+    @Override
+    public void apply(RequestTemplate requestTemplate) {
+        RequestAttributes requestAttributes = RequestContextHolder.getRequestAttributes();
+        if (requestAttributes instanceof ServletRequestAttributes servletRequestAttributes) {
+            HttpServletRequest httpServletRequest = servletRequestAttributes.getRequest();
+            String authorization = httpServletRequest.getHeader(HttpHeaders.AUTHORIZATION);
+            if (authorization != null) {
+                requestTemplate.header(HttpHeaders.AUTHORIZATION, authorization);
+            }
+        }
+    }
+}

--- a/ticket-manager/ai-tools-gateway/src/main/java/pl/ticket/aitoolsgateway/config/SecurityConfig.java
+++ b/ticket-manager/ai-tools-gateway/src/main/java/pl/ticket/aitoolsgateway/config/SecurityConfig.java
@@ -1,0 +1,37 @@
+package pl.ticket.aitoolsgateway.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    private final String[] swaggerApis = {
+            "/swagger-ui.html",
+            "/swagger-ui/**",
+            "/swagger-resources/**",
+            "/swagger-resources/configuration/ui/**",
+            "/swagger-resources/configuration/security/**",
+            "/v2/api-docs/**",
+            "/v3/api-docs/**",
+            "/webjars/**",
+            "/swagger-resources"
+    };
+
+    @Bean
+    public SecurityFilterChain securityWebFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers("/actuator/health", "/actuator/info").permitAll()
+                        .requestMatchers(swaggerApis).permitAll()
+                        .anyRequest().authenticated())
+                .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()));
+        return http.build();
+    }
+}

--- a/ticket-manager/ai-tools-gateway/src/main/java/pl/ticket/aitoolsgateway/service/AiToolsGatewayService.java
+++ b/ticket-manager/ai-tools-gateway/src/main/java/pl/ticket/aitoolsgateway/service/AiToolsGatewayService.java
@@ -1,0 +1,25 @@
+package pl.ticket.aitoolsgateway.service;
+
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.ai.tool.annotation.ToolParam;
+import org.springframework.stereotype.Service;
+import pl.ticket.dto.OrderSearchRequest;
+import pl.ticket.dto.OrderSearchResponse;
+import pl.ticket.feign.order.OrderClient;
+
+@Service
+public class AiToolsGatewayService {
+
+    private final OrderClient orderClient;
+
+    public AiToolsGatewayService(OrderClient orderClient) {
+        this.orderClient = orderClient;
+    }
+
+    @Tool(name = "order-service.searchOrders", description = "Wyszukuje zamówienia użytkownika po filtrach, sortowaniu i paginacji.")
+    public OrderSearchResponse searchOrders(
+            @ToolParam(description = "Parametry wyszukiwania zamówień", required = false)
+            OrderSearchRequest request) {
+        return orderClient.searchOrders(request);
+    }
+}

--- a/ticket-manager/ai-tools-gateway/src/main/java/pl/ticket/aitoolsgateway/swagger/OpenApiConfigs.java
+++ b/ticket-manager/ai-tools-gateway/src/main/java/pl/ticket/aitoolsgateway/swagger/OpenApiConfigs.java
@@ -1,0 +1,40 @@
+package pl.ticket.aitoolsgateway.swagger;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Configuration
+public class OpenApiConfigs {
+
+    @Bean
+    public OpenAPI customOpenAPI(
+            @Value("${openapi.info.title}") String serviceTitle,
+            @Value("${openapi.info.version}") String serviceVersion,
+            @Value("${openapi.service.url}") String url,
+            @Value("${openapi.service.description}") String desc) {
+        return new OpenAPI()
+                .servers(List.of(new Server().url(url)))
+                .info(new Info()
+                        .title(serviceTitle)
+                        .version(serviceVersion)
+                        .description(desc))
+                .addSecurityItem(new SecurityRequirement().addList("Bearer Authentication"))
+                .components(new Components().addSecuritySchemes("Bearer Authentication", createAPIKeyScheme()));
+    }
+
+    private SecurityScheme createAPIKeyScheme() {
+        return new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .bearerFormat("JWT")
+                .scheme("bearer");
+    }
+}

--- a/ticket-manager/ai-tools-gateway/src/main/resources/application-mcp-client-example.yml
+++ b/ticket-manager/ai-tools-gateway/src/main/resources/application-mcp-client-example.yml
@@ -1,0 +1,10 @@
+spring:
+  ai:
+    mcp:
+      client:
+        enabled: true
+        streamable-http:
+          connections:
+            company-gateway:
+              url: http://ai-tools-gateway:8105
+              endpoint: /mcp

--- a/ticket-manager/ai-tools-gateway/src/main/resources/application.yml
+++ b/ticket-manager/ai-tools-gateway/src/main/resources/application.yml
@@ -1,0 +1,47 @@
+server:
+  port: 8105
+
+spring:
+  application:
+    name: ai-tools-gateway
+  ai:
+    mcp:
+      server:
+        enabled: true
+        protocol: STREAMABLE
+        endpoint: /mcp
+        name: company-gateway
+        version: 1.0.0
+        annotation-scanner:
+          enabled: true
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: http://localhost:8085/realms/ticket-manager-realm
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,metrics
+
+openapi:
+  info:
+    title: AI Tools Gateway Doc
+    version: 1.0.0
+  service:
+    description: AI Tools Gateway APIs
+    url: http://localhost:8105
+
+eureka:
+  client:
+    service-url:
+      defaultZone: http://localhost:8761/eureka
+    fetch-registry: true
+    register-with-eureka: true
+
+ai-tools-gateway:
+  tools:
+    timeout-ms: 3000
+    audit-enabled: true

--- a/ticket-manager/docs/ai-agent-mcp-migration-plan.md
+++ b/ticket-manager/docs/ai-agent-mcp-migration-plan.md
@@ -1,0 +1,252 @@
+# AI Agent + MCP – analiza i plan migracji
+
+## 1) Analiza aktualnego `ai-agent`
+
+## Co działa dzisiaj
+- `AiAgentController` wystawia endpointy:
+  - `POST /api/v1/aiagent/plan` – zwraca sam plan,
+  - `POST /api/v1/aiagent/ask` – tworzy plan i wykonuje pierwszy krok typu `TOOL`.
+- `PlannerService` buduje prompt planera, woła model przez `ChatClient`, waliduje JSON przez schema validator i ma pojedynczy retry „repair”.
+- `AiAgentService` wykonuje **jeden** tool: `order-service.searchOrders` i mapuje `args` na `OrderSearchRequest`, a realne wykonanie robi przez `OrderClient` (Feign).
+- Plan i tool-contract są obecnie „zaszyte” w promptcie + kodzie wykonywania (switch po nazwie narzędzia).
+
+## Ograniczenia obecnego podejścia
+- Tool-calling jest „lokalny” (w praktyce ręczny dispatcher), brak dynamicznego discovery narzędzi.
+- Brak separacji odpowiedzialności między orkiestracją LLM i logiką biznesową narzędzi.
+- Rosnące ryzyko konfliktu nazw narzędzi przy dołączaniu external MCP servers.
+- Trudniejsze wersjonowanie narzędzi (zmiana kontraktu wymaga zmian w agencie).
+
+---
+
+## 2) Docelowa architektura i podział odpowiedzialności
+
+## Architektura docelowa
+- `ai-agent`:
+  - odpowiedzialny za rozmowę, planowanie i orkiestrację,
+  - działa jako MCP client do wielu serwerów,
+  - utrzymuje lokalnie tylko „meta-tools” techniczne i policyjne.
+- `ai-tools-gateway`:
+  - wewnętrzny MCP server,
+  - wystawia biznesowe narzędzia domenowe (orders, payments, promo, knowledge),
+  - agreguje i normalizuje odpowiedzi z mikroserwisów.
+- external MCP servers:
+  - źródła pomocnicze (docs/github/knowledge),
+  - odseparowane sandboxem i whitelistem narzędzi.
+
+## Co przenieść do `ai-tools-gateway` (MCP tools)
+Przenoś wszystko, co:
+- ma logikę biznesową lub wymaga dostępu do wewnętrznych systemów,
+- jest współdzielone między agentami,
+- wymaga centralnego audytu/uprawnień.
+
+Przykłady:
+- `tm.orders.getOrderStatus`,
+- `tm.orders.searchOrders`,
+- `tm.promotions.getTerms`,
+- `tm.knowledge.search` (RAG dla firmowej wiedzy),
+- `tm.customer.getProfile`.
+
+## Co może zostać lokalnie w `ai-agent`
+- Narzędzia pomocnicze bez dostępu do systemów krytycznych:
+  - normalizacja promptu,
+  - redakcja PII przed logowaniem,
+  - krótkie utility (`date_now`, `format_currency`).
+- Guardrails/policy tools:
+  - klasyfikacja intencji,
+  - check polityk bezpieczeństwa,
+  - wybór routingowy (który MCP server ma być użyty).
+
+## Namespace / prefiksy narzędzi (antykolizyjne)
+Rekomendacja:
+- wewnętrzny gateway: `tm.<domain>.<action>`
+  - np. `tm.orders.search`, `tm.knowledge.search`.
+- external serwery:
+  - zachowuj oryginalną nazwę, ale mapuj do lokalnego aliasu w agencie:
+    - `ext.github.search_repositories`,
+    - `ext.docs.fetch`.
+- narzędzia lokalne:
+  - `local.<capability>`.
+
+Dodatkowo:
+- trzymaj centralny registry nazw + whitelistę per use-case,
+- wersjonowanie kontraktów narzędzi przez suffix lub metadata (`x-version`).
+
+---
+
+## 3) Konkretna lista zmian w `ai-agent`
+
+## Zależności (`pom.xml`)
+Dodaj (w module `ai-agent`):
+- `org.springframework.ai:spring-ai-starter-model-*` (zależnie od modelu, np. ollama/openai),
+- `org.springframework.ai:spring-ai-starter-mcp-client`,
+- `org.springframework.boot:spring-boot-starter-validation` (jeśli jeszcze brak),
+- opcjonalnie resilience:
+  - `org.springframework.boot:spring-boot-starter-aop`,
+  - `io.github.resilience4j:resilience4j-spring-boot3`.
+
+Jeśli projekt jest na starszym BOM Spring Boot/Cloud, najpierw ujednolić wersje kompatybilne ze Spring AI i MCP.
+
+## `application.yml` – konfiguracja MCP client (internal + external)
+Przykładowy szkic:
+
+```yaml
+spring:
+  ai:
+    mcp:
+      client:
+        enabled: true
+        request-timeout: 5s
+        servers:
+          ai-tools-gateway:
+            transport: sse
+            url: http://ai-tools-gateway:8080/mcp
+            enabled-tools:
+              - tm.orders.search
+              - tm.orders.getStatus
+              - tm.knowledge.search
+          github-docs:
+            transport: sse
+            url: https://external-mcp.example.com/mcp
+            headers:
+              Authorization: Bearer ${EXTERNAL_MCP_TOKEN}
+            enabled-tools:
+              - ext.github.search_repositories
+              - ext.docs.fetch
+
+ai-agent:
+  tools:
+    allow-list:
+      - tm.orders.search
+      - tm.orders.getStatus
+      - tm.knowledge.search
+      - ext.github.search_repositories
+      - local.date_now
+```
+
+Uwaga: nazwy właściwości mogą się różnić w zależności od wersji startera MCP; trzymaj się jednego release train i jego dokumentacji.
+
+## Kod – ChatClient + ToolCallbackProvider + filtrowanie
+Zmiany projektowe:
+1. **Oddziel planner od execution layer**:
+   - planner zwraca plan z nazwami narzędzi MCP (`tm.*`, `ext.*`, `local.*`).
+2. **Execution layer**:
+   - adapter `ToolExecutor` z trzema backendami:
+     - LocalToolExecutor,
+     - McpToolExecutor (internal),
+     - McpToolExecutor (external).
+3. **ToolCallbackProvider / registry**:
+   - buduje listę dostępnych narzędzi z MCP + lokalnych,
+   - stosuje allow-listę per endpoint/use-case,
+   - loguje `toolName`, `serverId`, `duration`, `status`.
+4. **Walidacja wejścia/wyjścia**:
+   - JSON Schema per tool,
+   - hard limit na argumenty i response size.
+5. **Fallback policy**:
+   - timeout MCP => alternatywa lokalna albo odpowiedź kontrolowana.
+
+---
+
+## 4) Minimalny szkielet `ai-tools-gateway` (MCP server)
+
+## Struktura
+- nowy moduł: `ai-tools-gateway`
+- pakiety:
+  - `pl.ticket.aitoolsgateway.mcp` – definicje tools/resources,
+  - `pl.ticket.aitoolsgateway.service` – logika biznesowa,
+  - `pl.ticket.aitoolsgateway.security` – auth + audyt.
+
+## Zależności
+- `spring-boot-starter-web` (lub webflux, zależnie od transportu MCP),
+- `spring-ai-starter-mcp-server`,
+- `spring-boot-starter-validation`,
+- `spring-boot-starter-security`,
+- `spring-boot-starter-actuator`,
+- opcjonalnie `resilience4j`.
+
+## `application.yml` (szkielet)
+
+```yaml
+server:
+  port: 8105
+
+spring:
+  application:
+    name: ai-tools-gateway
+  ai:
+    mcp:
+      server:
+        enabled: true
+        path: /mcp
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,metrics
+
+gateway:
+  security:
+    required-audience: ai-agent
+  tools:
+    timeout: 3s
+```
+
+## Przykładowe MCP tools
+1) `tm.orders.getOrderStatus`
+- input: `{ "orderId": "..." }`
+- output: `{ "orderId": "...", "status": "PAID", "updatedAt": "..." }`
+- backend: `OrderClient`/`OrderQueryService`.
+
+2) `tm.knowledge.search`
+- input: `{ "query": "...", "topK": 3 }`
+- output: `{ "results": [{"title":"...","snippet":"...","source":"..."}] }`
+- backend: firmowa baza wiedzy / indeks.
+
+## Zasady bezpieczeństwa na start
+- AuthN: JWT service-to-service (audience = `ai-tools-gateway`).
+- AuthZ: scope per tool (np. `tools:orders.read`, `tools:knowledge.read`).
+- Audyt: log każdego wywołania (`traceId`, `subject`, `tool`, `argsHash`, `latency`, `resultCode`).
+- Timeouty/circuit-breaker: per tool + bulkhead.
+- PII: maskowanie danych w logach i telemetry.
+
+---
+
+## 5) Plan migracji bez przestoju produkcji
+
+## Etap 1 – uruchomienie gateway MCP z 1 tool
+- Postaw `ai-tools-gateway` z `tm.orders.getOrderStatus`.
+- Zaimplementuj pełny audyt + auth + timeout.
+- Brak zmian ruchu produkcyjnego (tylko testy integracyjne i shadow traffic).
+
+## Etap 2 – podłączenie `ai-agent` do gateway MCP
+- Dodaj MCP client config do `ai-agent`.
+- Włącz feature flag: `aiagent.mcp.internal.enabled=false` domyślnie.
+- Canary: 1–5% ruchu przez MCP, reszta starym lokalnym toolem.
+
+## Etap 3 – stopniowe przenoszenie narzędzi
+- Dla każdego narzędzia:
+  1) implementacja w gateway,
+  2) kontrakt + testy,
+  3) dual-run (local + MCP) i porównanie odpowiedzi,
+  4) przełączenie flagą,
+  5) usunięcie starej implementacji lokalnej.
+- Priorytet: narzędzia o najwyższej wartości biznesowej i stabilnym API.
+
+## Etap 4 – dodanie external MCP servers
+- Dodaj 1 external serwer na początek (np. docs), tylko read-only.
+- Wprowadź whitelistę narzędzi i osobne limity budżetu/tokenów.
+- Routing policy:
+  - pytania domenowe → `tm.*`,
+  - dokumentacja/public knowledge → `ext.*`.
+- Stopniowo zwiększaj zakres i monitoruj jakość odpowiedzi + koszty.
+
+---
+
+## KPI i gotowość produkcyjna
+- P95 latency per tool/server,
+- wskaźnik timeout/error,
+- procent fallbacków,
+- zgodność odpowiedzi MCP vs legacy tool,
+- koszt/tokeny per ścieżka (`tm`, `ext`, `local`).
+
+Taki plan pozwala przejść na MCP bez „big-bang” i bez utraty stabilności obecnego `ai-agent`.

--- a/ticket-manager/pom.xml
+++ b/ticket-manager/pom.xml
@@ -26,6 +26,7 @@
         <module>notification-client</module>
         <module>discount</module>
         <module>ai-agent</module>
+        <module>ai-tools-gateway</module>
     </modules>
     <!-- update versions -->
     <properties>


### PR DESCRIPTION
### Motivation

- Introduce an internal MCP server to centralize business tools previously embedded in the agent and enable dynamic tool discovery and execution separation.
- Provide a secure, documented gateway for agent-to-service calls with consistent auth and OpenAPI metadata.
- Add a concrete starting tool (`order-service.searchOrders`) to allow incremental migration and testing of the MCP-based architecture.

### Description

- Add new `ai-tools-gateway` module with `pom.xml`, application configuration (`application.yml`) and an example MCP client config (`application-mcp-client-example.yml`).
- Implement main application class `AiToolsGatewayApplication` with `@EnableFeignClients` and add Feign-based `AiToolsGatewayService` exposing a `@Tool` method `order-service.searchOrders` that delegates to `OrderClient`.
- Add security and infra pieces: `SecurityConfig` for OAuth2 resource server rules, `AuthFeignInterceptor` to propagate `Authorization` header to downstream Feign calls, and `OpenApiConfigs` for OpenAPI + bearer auth setup.
- Add documentation and migration guidance: `README.md` for the module and a comprehensive `docs/ai-agent-mcp-migration-plan.md`, and update parent `pom.xml` to include the new module.

### Testing

- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0c25fc2c483268f11700cc6494a89)